### PR TITLE
[PROPOSAL] Add UInt64 Support

### DIFF
--- a/src/attribute.rs
+++ b/src/attribute.rs
@@ -8,6 +8,7 @@ use crate::Element;
 #[derive(Clone, Debug)]
 pub enum Attribute {
     Element(Option<Element>),
+    UInt64(u64),
     Integer(i32),
     Float(f32),
     Boolean(bool),
@@ -24,6 +25,7 @@ pub enum Attribute {
     Matrix(Matrix),
 
     ElementArray(Vec<Option<Element>>),
+    UInt64Array(Vec<u64>),
     IntegerArray(Vec<i32>),
     FloatArray(Vec<f32>),
     BooleanArray(Vec<bool>),
@@ -184,6 +186,7 @@ impl<'a> TryFrom<&'a Attribute> for &'a Element {
 }
 
 declare_attribute!(Option<Element>, Attribute::Element, Attribute::ElementArray);
+declare_attribute!(u64, Attribute::UInt64, Attribute::UInt64Array);
 declare_attribute!(i32, Attribute::Integer, Attribute::IntegerArray);
 declare_attribute!(f32, Attribute::Float, Attribute::FloatArray);
 declare_attribute!(bool, Attribute::Boolean, Attribute::BooleanArray);

--- a/src/serializers/binary.rs
+++ b/src/serializers/binary.rs
@@ -315,6 +315,9 @@ impl Serializer for BinarySerializer {
 
                         writer.write_int(index as i32)?;
                     }
+                    Attribute::UInt64(value) => {
+                        todo!()
+                    }
                     Attribute::Integer(value) => {
                         writer.write_byte(2)?;
                         writer.write_int(*value)?;
@@ -425,6 +428,9 @@ impl Serializer for BinarySerializer {
 
                             writer.write_int(index as i32)?;
                         }
+                    }
+                    Attribute::UInt64Array(value) => {
+                        todo!()
                     }
                     Attribute::IntegerArray(value) => {
                         writer.write_byte(16)?;

--- a/src/serializers/keyvalues2.rs
+++ b/src/serializers/keyvalues2.rs
@@ -33,6 +33,8 @@ pub enum Keyvalues2SerializationError {
     InvalidToken(usize),
     #[error("Unfinished Attribute In Element")]
     UnfinishedAttribute,
+    #[error("Failed To Parse UInt64 On Line: {0}")]
+    FailedToParseUInt64(usize),
     #[error("Failed To Parse Integer On Line: {0}")]
     FailedToParseInteger(usize),
     #[error("Failed To Parse Float On Line: {0}")]
@@ -139,6 +141,7 @@ impl<T: Write> StringWriter<T> {
 
                     self.write_line(&format!("{:?} \"{}\" \"\"", name, attribute_type_name))?;
                 }
+                Attribute::UInt64(value) => self.write_line(&format!("{:?} \"{}\" \"{}\"", name, attribute_type_name, value))?,
                 Attribute::Integer(value) => self.write_line(&format!("{:?} \"{}\" \"{}\"", name, attribute_type_name, value))?,
                 Attribute::Float(value) => self.write_line(&format!("{:?} \"{}\" \"{}\"", name, attribute_type_name, value))?,
                 Attribute::Boolean(value) => self.write_line(&format!("{:?} \"{}\" \"{}\"", name, attribute_type_name, *value as u8))?,
@@ -236,6 +239,17 @@ impl<T: Write> StringWriter<T> {
                     self.write_close_bracket()?;
                 }
                 Attribute::IntegerArray(values) => {
+                    self.write_line(&format!("{:?} \"{}\"", name, attribute_type_name))?;
+                    self.write_open_bracket()?;
+                    if let Some((last, values)) = values.split_last() {
+                        for value in values {
+                            self.write_line(&format!("\"{}\",", value))?;
+                        }
+                        self.write_line(&format!("\"{}\"", last))?;
+                    }
+                    self.write_close_bracket()?;
+                }
+                Attribute::UInt64Array(values) => {
                     self.write_line(&format!("{:?} \"{}\"", name, attribute_type_name))?;
                     self.write_open_bracket()?;
                     if let Some((last, values)) = values.split_last() {
@@ -423,6 +437,7 @@ impl<T: Write> StringWriter<T> {
     fn get_attribute_type_name(attribute: &Attribute) -> &'static str {
         match attribute {
             Attribute::Element(_) => "element",
+            Attribute::UInt64(_) => "uint64",
             Attribute::Integer(_) => "int",
             Attribute::Float(_) => "float",
             Attribute::Boolean(_) => "bool",
@@ -438,6 +453,7 @@ impl<T: Write> StringWriter<T> {
             Attribute::Quaternion(_) => "quaternion",
             Attribute::Matrix(_) => "matrix",
             Attribute::ElementArray(_) => "element_array",
+            Attribute::UInt64Array(_) => "uint64_array",
             Attribute::IntegerArray(_) => "int_array",
             Attribute::FloatArray(_) => "float_array",
             Attribute::BooleanArray(_) => "bool_array",
@@ -698,6 +714,14 @@ fn read_attribute<T: BufRead>(
             StringToken::String(value) => match value.parse() {
                 Ok(value) => Ok(Attribute::Integer(value)),
                 Err(_) => Err(Keyvalues2SerializationError::FailedToParseInteger(reader.line_count)),
+            },
+            _ => Err(Keyvalues2SerializationError::InvalidToken(reader.line_count)),
+        },
+        "uint64" => match attribute_value {
+            StringToken::String(value) => {
+                let int = u64::from_str_radix(value.as_str().strip_prefix("0x").unwrap(), 16).expect("Failed to parse hex to u64");
+
+                Ok(Attribute::UInt64(int))
             },
             _ => Err(Keyvalues2SerializationError::InvalidToken(reader.line_count)),
         },


### PR DESCRIPTION
As the title suggests, I think adding UInt64 would be a good move, *.VMAP files are DMX Binary v4 and KV2 respectively (depending on whether you save normally or "Save Copy as Text"), they only have a minute difference of having the "uint64" type which to my knowledge right now is the only type added. It's stored as hex, so we convert it back using radix and trim_prefix into a u64. This PR currently only adds the support for ASCII, binary will be implemented soon enough.